### PR TITLE
feat: Add basic fit example of likelihood

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -80,6 +80,11 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     required=False,
 )
 def main(backend):
+    """
+    Example of fitting a public workspace from HEPData. The fit selects a single
+    signal point from the signal patchset and then patches the background only
+    model to create a workspace
+    """
     pyhf.set_backend(backend)
     print(f"Backend set to: {backend}")
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,0 +1,96 @@
+import requests
+import hashlib
+import tarfile
+import os
+import json
+from datetime import datetime
+import pyhf
+
+
+def electroweakinos_likelihoods_download():
+    """Download the electroweakinos likelihoods tarball from HEPData"""
+    oneLbb_HEPData_URL = "https://www.hepdata.net/record/resource/1267798?view=true"
+    targz_filename = "oneLbb_workspaces.tar.gz"
+    response = requests.get(oneLbb_HEPData_URL, stream=True)
+    assert response.status_code == 200
+    with open(targz_filename, "wb") as file:
+        file.write(response.content)
+    assert (
+        hashlib.sha256(open(targz_filename, "rb").read()).hexdigest()
+        == "64bbbef9f1aaf9e30d75c8975de4789484329b2b825d89331a6f2081661aa728"
+    )
+    # Open as a tarfile
+    yield tarfile.open(targz_filename, "r:gz")
+    os.remove(targz_filename)
+
+
+def get_json_from_tarfile(tarfile, json_name):
+    json_file = tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
+    return json.loads(json_file)
+
+
+def get_bkg_and_signal(tarfile, directory_name, model_point):
+    background_only = get_json_from_tarfile(tarfile, directory_name + "/BkgOnly.json",)
+    patchset = pyhf.PatchSet(
+        get_json_from_tarfile(tarfile, directory_name + "/patchset.json")
+    )
+    signal_patch = patchset[model_point]
+    return background_only, signal_patch
+
+
+def calculate_CLs(bkgonly_json, signal_patch_json):
+    """
+    Calculate the observed CLs and the expected CLs band from a background only
+    and signal patch.
+
+    Args:
+        bkgonly_json: The JSON for the background only model
+        signal_patch_json: The JSON Patch for the signal model
+
+    Returns:
+        CLs_obs: The observed CLs value
+        CLs_exp: List of the expected CLs value band
+    """
+    workspace = pyhf.workspace.Workspace(bkgonly_json)
+    model = workspace.model(
+        measurement_name=None,
+        patches=[signal_patch_json],
+        modifier_settings={
+            "normsys": {"interpcode": "code4"},
+            "histosys": {"interpcode": "code4p"},
+        },
+    )
+    result = pyhf.infer.hypotest(
+        1.0, workspace.data(model), model, qtilde=True, return_expected_set=True
+    )
+    return result[0].tolist()[0], result[-1].ravel().tolist()
+
+
+def main(backend=None):
+    if backend is None:
+        backend = "numpy"
+    pyhf.set_backend(backend)
+    print(f"Backend set to: {backend}")
+
+    oneLbb_background, oneLbb_Wh_hbb_750_100_signal_patch = get_bkg_and_signal(
+        electroweakinos_likelihoods_download().__next__(),
+        "1Lbb-likelihoods-hepdata",
+        (750, 100),  # "C1N2_Wh_hbb_750_100(750, 100)"
+    )
+
+    print("Starting fit\n")
+    fit_start_time = datetime.now()
+    CLs_obs, CLs_exp = calculate_CLs(
+        oneLbb_background, oneLbb_Wh_hbb_750_100_signal_patch
+    )
+    fit_end_time = datetime.now()
+    fit_time = fit_end_time - fit_start_time
+
+    print(f"\nfit C1N2_Wh_hbb_750_100 in {fit_time} seconds\n")
+    print(f"CLs_obs: {CLs_obs}")
+    print(f"CLs_exp: {CLs_exp}")
+
+
+if __name__ == "__main__":
+    # main()
+    main("pytorch")

--- a/examples/example.py
+++ b/examples/example.py
@@ -83,8 +83,10 @@ def main(backend):
     pyhf.set_backend(backend)
     print(f"Backend set to: {backend}")
 
+    # Using the generator to cleanup automatically
+    tarfile = [tgz for tgz in electroweakinos_likelihoods_download()][0]
     oneLbb_background, oneLbb_Wh_hbb_750_100_signal_patch = get_bkg_and_signal(
-        electroweakinos_likelihoods_download().__next__(),
+        tarfile,
         "1Lbb-likelihoods-hepdata",
         (750, 100),  # "C1N2_Wh_hbb_750_100(750, 100)"
     )

--- a/examples/example.py
+++ b/examples/example.py
@@ -63,7 +63,8 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     result = pyhf.infer.hypotest(
         1.0, workspace.data(model), model, qtilde=True, return_expected_set=True
     )
-    return result[0].tolist()[0], result[-1].ravel().tolist()
+    # return result[0].tolist()[0], result[-1].ravel().tolist()
+    return result[0].tolist()[0], result[-1].tolist()
 
 
 def main(backend=None):
@@ -78,7 +79,7 @@ def main(backend=None):
         (750, 100),  # "C1N2_Wh_hbb_750_100(750, 100)"
     )
 
-    print("Starting fit\n")
+    print("\nStarting fit\n")
     fit_start_time = datetime.now()
     CLs_obs, CLs_exp = calculate_CLs(
         oneLbb_background, oneLbb_Wh_hbb_750_100_signal_patch
@@ -86,11 +87,11 @@ def main(backend=None):
     fit_end_time = datetime.now()
     fit_time = fit_end_time - fit_start_time
 
-    print(f"\nfit C1N2_Wh_hbb_750_100 in {fit_time} seconds\n")
+    print(f"fit C1N2_Wh_hbb_750_100 in {fit_time} seconds\n")
     print(f"CLs_obs: {CLs_obs}")
     print(f"CLs_exp: {CLs_exp}")
 
 
 if __name__ == "__main__":
-    # main()
+    main()
     main("pytorch")

--- a/examples/example.py
+++ b/examples/example.py
@@ -64,8 +64,10 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     result = pyhf.infer.hypotest(
         1.0, workspace.data(model), model, qtilde=True, return_expected_set=True
     )
-    # return result[0].tolist()[0], result[-1].ravel().tolist()
-    return result[0].tolist()[0], result[-1].tolist()
+    if isinstance(pyhf.tensorlib, pyhf.tensor.pytorch_backend):
+        return result[0].tolist()[0], result[-1].tolist()
+    else:
+        return result[0].tolist()[0], result[-1].ravel().tolist()
 
 
 @click.command()

--- a/examples/example.py
+++ b/examples/example.py
@@ -83,7 +83,7 @@ def main(backend):
     """
     Example of fitting a public workspace from HEPData. The fit selects a single
     signal point from the signal patchset and then patches the background only
-    model to create a workspace
+    model to create a workspace.
     """
     pyhf.set_backend(backend)
     print(f"Backend set to: {backend}")

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,6 +4,7 @@ import tarfile
 import os
 import json
 from datetime import datetime
+import click
 import pyhf
 
 
@@ -67,9 +68,16 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     return result[0].tolist()[0], result[-1].tolist()
 
 
-def main(backend=None):
-    if backend is None:
-        backend = "numpy"
+@click.command()
+@click.option(
+    "-b",
+    "--backend",
+    "backend",
+    help="Name of the pyhf backend to run with.",
+    default="numpy",
+    required=False,
+)
+def main(backend):
     pyhf.set_backend(backend)
     print(f"Backend set to: {backend}")
 
@@ -94,4 +102,3 @@ def main(backend=None):
 
 if __name__ == "__main__":
     main()
-    main("pytorch")


### PR DESCRIPTION
Add an example of how to fit a public likehood using the ["Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two b-jets in (pp) collisions at s√=13 TeV with the ATLAS detector" analysis](https://www.hepdata.net/record/ins1755298?version=2) as it is the first one to publish a [patch set](https://scikit-hep.org/pyhf/_generated/pyhf.patchset.PatchSet.html).


The example can be run from the CLI generated with Click

```
$ python examples/example.py --help
Usage: example.py [OPTIONS]

  Example of fitting a public workspace from HEPData. The fit selects a
  single signal point from the signal patchset and then patches the
  background only model to create a workspace.

Options:
  -b, --backend TEXT  Name of the pyhf backend to run with.
  --help              Show this message and exit.
```

so for example

```
$ python examples/example.py --backend pytorch
```

```
* Add example of pyhf fitting a published likelihood
* Give example CLI for setting backend with Click
```