### PR TITLE
feat: Add requirements.txt for environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Benchmarking of hardware acceleration of `pyhf`
 
+## Environment
+
+For the time being, until a library can be created, use the `requirements.txt` to also serve setup duty in your virtual environment in addition to providing a reproducible benchmarking environment.
+
+```
+(pyhf-benchmark) $ python -m pip install -r requirements.txt
+```
+
 ## Authors
 
 `pyhf-benchmark` is openly developed by [Bo Zheng](https://iris-hep.org/fellows/BoZheng.html) and the [`pyhf` dev team](https://scikit-hep.org/pyhf/#authors).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyhf[backends]~=0.4


### PR DESCRIPTION
For the time being, until a library can be created, use the `requirements.txt` to also serve setup duty in your virtual environment in addition to providing a reproducible benchmarking environment.

```
(pyhf-benchmark) $ python -m pip install -r requirements.txt
```

This is all that is needed to run the [`examples/example.py`](https://github.com/pyhf/pyhf-benchmark/blob/255572429444e9f06079fc5ad42ab72fcc9ce1d7/examples/example.py).

```
* Add requirements.txt for environment setup for time being
* Add section to README on environment setup
```