### PR TITLE
feat: Add tensorflow support

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -89,6 +89,8 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     )
     if isinstance(pyhf.tensorlib, pyhf.tensor.pytorch_backend):
         return result[0].tolist()[0], result[-1].tolist()
+    elif isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
+        return result[0].numpy().tolist()[0], result[-1].numpy().ravel().tolist()
     else:
         return result[0].tolist()[0], result[-1].ravel().tolist()
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import shutil
 import pyhf
 import warnings
+import tensorflow as tf
 
 warnings.filterwarnings('ignore')
 
@@ -149,6 +150,8 @@ def main(backend, path, url, model_point):
       https://github.com/pyhf/pyhf-benchmark
 
     """
+    if backend == "tensorflow":
+        tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
     pyhf.set_backend(backend)
     print(f"Backend set to: {backend}")

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -151,7 +151,7 @@ def main(backend, path, url, model_point):
 
     """
     if backend == "tensorflow":
-        tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+        tf.get_logger().setLevel('ERROR')
 
     pyhf.set_backend(backend)
     print(f"Backend set to: {backend}")


### PR DESCRIPTION
In this PR, I want to add `tensorflow` support to make `pyhf.infer.hypotest` computation. In the previous work, I tried to use
```
import warnings
warnings.filterwarnings('ignore')
```
to avoid print warning information in the console. But when I use `tensorflow` backend, the console still prints out warning information. Hope anyone knows how to solve the problem can give me some help. Thank you!

<img width="1386" alt="屏幕快照 2020-06-15 上午11 53 20" src="https://user-images.githubusercontent.com/19755247/84686179-1cb9fb00-af01-11ea-8012-4a07b653e9c9.png">

