### PR TITLE
build: Remove redundancy in setup extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require["test"] = sorted(
     set(
         [
             "check-manifest",
-            "pytest~=5.2",
+            "pytest~=6.0",
             "pytest-cov~=2.8",
             "pytest-console-scripts~=0.2",
         ]

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,7 @@ extras_require["develop"] = sorted(
     set(
         extras_require["test"]
         + extras_require["lint"]
-        + [
-            "check-manifest",
-            "pytest~=5.2",
-            "pytest-cov~=2.8",
-            "pytest-console-scripts~=0.2",
-            "bumpversion~=0.5",
-            "pre-commit",
-            "twine",
-        ]
+        + ["check-manifest", "bumpversion~=0.5", "pre-commit", "twine",]
     )
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
In `setup.py` there is currently redundant overlap between the definitions of the `test` extra and the `develop` extra. This PR removes that redundancy. Additionally, it updates `pytest` to the `v6.X` series of releases.


```
* Remove redundancy in 'develop' extra covered by 'test' extra
* Update pytest to releases compatible with v6.X
```